### PR TITLE
Write to bluetooth upon changing settings

### DIFF
--- a/lib/assets/constants.dart
+++ b/lib/assets/constants.dart
@@ -25,5 +25,6 @@ class Constants {
   static double selectorHeight = 300;
   static double selectorHorizontalPadding = 90;
   static double selectorVerticalPadding = 30;
+  static int throttleTimerDuration = 200;
 }
 

--- a/lib/utils/lights/lights_cubit.dart
+++ b/lib/utils/lights/lights_cubit.dart
@@ -8,7 +8,7 @@ import '../../assets/constants.dart';
 class LightsCubit extends Cubit<LightsState> {
   final BluetoothCubit _bluetooth;
   Timer? _throttleTimer;
-  static const _throttleDuration = Duration(milliseconds: 200);
+  static final _throttleDuration = Duration(milliseconds: Constants.throttleTimerDuration);
   bool _isThrottled = false;
   LightsCubit(Module module, this._bluetooth)
       : super(LightsState(module: module));


### PR DESCRIPTION
This MR will:
- Change the app behaviour to write to bluetooth everytime there is a settings change with the light. This allows the user to see live the changes they're making on the light fixture.
- Adds a "throttle timer" to the LightsCubit write function. This timer currently has a 200ms timer to prevent the bluetooth from spamming the ESP32 and overwhelming it with commands. We will need to test the real speed at which the ESP32 can process the bluetooth writes since at the moment the only way of checking is through the CLI print statements which could be much slower than the actual time it takes for the bluetooth to be processed.